### PR TITLE
WINDUP-2172 Updated tests dependencies

### DIFF
--- a/model/pom.xml
+++ b/model/pom.xml
@@ -36,9 +36,9 @@
 
         <!-- Hibernate -->
         <dependency>
-            <groupId>org.hibernate.javax.persistence</groupId>
-            <artifactId>hibernate-jpa-2.2-api</artifactId>
-            <version>1.0.0.Beta2</version>
+            <groupId>javax.persistence</groupId>
+            <artifactId>javax.persistence-api</artifactId>
+            <version>2.2</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,8 @@
         <windup.web.scm.url>http://github.com/windup/windup-web</windup.web.scm.url>
 
         <windup.distribution.name>rhamt-cli</windup.distribution.name>
-        <version.hibernate>5.3.6.Final</version.hibernate>
+        <version.hibernate>5.3.7.Final</version.hibernate>
+        <version.undertow>2.0.15.Final</version.undertow>
     </properties>
 
     <scm>
@@ -105,7 +106,7 @@
             <dependency>
                 <groupId>org.jboss.arquillian</groupId>
                 <artifactId>arquillian-bom</artifactId>
-                <version>1.1.11.Final</version>
+                <version>1.4.1.Final</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -258,7 +259,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>2.20</version>
+                    <version>2.22.1</version>
                     <configuration>
                         <systemPropertyVariables>
                             <wildfly.version>${version.wildfly}</wildfly.version>

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -54,9 +54,9 @@
 
         <!-- Hibernate -->
         <dependency>
-            <groupId>org.hibernate.javax.persistence</groupId>
-            <artifactId>hibernate-jpa-2.2-api</artifactId>
-            <version>1.0.0.Beta2</version>
+            <groupId>javax.persistence</groupId>
+            <artifactId>javax.persistence-api</artifactId>
+            <version>2.2</version>
         </dependency>
         <dependency>
             <groupId>org.hibernate</groupId>
@@ -215,24 +215,36 @@
             <scope>test</scope>
             <type>pom</type>
         </dependency>
+        <dependency>
+            <groupId>org.jboss.xnio</groupId>
+            <artifactId>xnio-api</artifactId>
+            <version>3.6.5.Final</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.xnio</groupId>
+            <artifactId>xnio-nio</artifactId>
+            <version>3.6.5.Final</version>
+            <scope>provided</scope>
+        </dependency>
 
         <!-- Needed for FileDefaultServlet -->
         <dependency>
             <groupId>io.undertow</groupId>
             <artifactId>undertow-core</artifactId>
-            <version>1.4.0.Final</version>
+            <version>${version.undertow}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>io.undertow</groupId>
             <artifactId>undertow-servlet</artifactId>
-            <version>1.4.0.Final</version>
+            <version>${version.undertow}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>io.undertow</groupId>
             <artifactId>undertow-websockets-jsr</artifactId>
-            <version>1.4.0.Final</version>
+            <version>${version.undertow}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -269,7 +281,7 @@
         <plugins>
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.19.1</version>
+                <version>2.22.1</version>
             </plugin>
             <plugin>
                 <artifactId>maven-war-plugin</artifactId>
@@ -488,7 +500,7 @@
                 <dependency>
                     <groupId>org.wildfly.arquillian</groupId>
                     <artifactId>wildfly-arquillian-container-managed</artifactId>
-                    <version>2.0.0.Final</version>
+                    <version>2.1.1.Final</version>
                     <scope>test</scope>
                 </dependency>
                 <dependency>


### PR DESCRIPTION
Added depedency `org.jboss.xnio:xnio-{api,nio}:3.6.5.Final` to solve a version conflict during tests execution (`java.lang.NoSuchMethodError: org.xnio.XnioWorker.getContextManager()Lorg/wildfly/common/context/ContextManager;`)

Updated (with versions declared in [JBoss Enterprise Application Platform Component Details](https://access.redhat.com/articles/112673#EAP_7) and [WildFly 15 release notes](https://issues.jboss.org/secure/ReleaseNote.jspa?projectId=12313721&version=12339953)):
* Undertow to 2.0.15.Final
* Hibernate to 5.3.7.Final
* org.hibernate.javax.persistence:hibernate-jpa-2.2-api:1.0.0.Beta2 updated to javax.persistence:javax.persistence-api:2.2
* org.wildfly.arquillian:wildfly-arquillian-container-managed to 2.1.1.Final (thanks to https://developer.jboss.org/thread/279328)
* maven-surefire-plugin to 2.22.1
* org.jboss.arquillian:arquillian-bom to 1.4.1.Final